### PR TITLE
Update boulderD9_profile.info.yml

### DIFF
--- a/boulderD9_profile.info.yml
+++ b/boulderD9_profile.info.yml
@@ -68,6 +68,7 @@ install:
   - ucb_admin_menus
   - ucb_focal_image_enable
   - ucb_bootstrap_layouts
+  - media_library_form_element
   
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.


### PR DESCRIPTION
Activates media library form element
Allows media library to load on forms
Needed to make background images work for layout builder (Is being worked on for core but not in core yet)

Sibling Repos:
https://github.com/CuBoulder/tiamat-theme/pull/141
https://github.com/CuBoulder/tiamat-project-template/pull/13
https://github.com/CuBoulder/ucb_bootstrap_layouts/pull/3