### PR TITLE
CuBoulder/tiamat-theme#82 adds CU Boulder Campus News module

### DIFF
--- a/boulderD9_profile.info.yml
+++ b/boulderD9_profile.info.yml
@@ -64,6 +64,7 @@ install:
   - simple_sitemap
   - cu_boulder_content_types
   - ucb_site_configuration
+  - ucb_campus_news
   - ucb_user_invite
   - ucb_admin_menus
   - ucb_focal_image_enable


### PR DESCRIPTION
Resolves CuBoulder/tiamat-theme/issues/82

Sister PR in: [tiamat-project-template](https://github.com/CuBoulder/tiamat-project-template/pull/14) (merge that one first)

Authors: @patrickbrown-io @TeddyBearX

**IMPORTANT: An issue exists with an absent `Access-Control-Allow-Origin` header on the CU Boulder Today site API. This will cause the functionality to be broken. For testing select "Disable Cross-Origin Restrictions" or similar in your browser's developer tools.** 

Known issues: "Illegal choice" log messages (does not affect functionality)