### PR TITLE
Adds Aggregator module and feed block

### DIFF
--- a/boulderD9_profile.info.yml
+++ b/boulderD9_profile.info.yml
@@ -56,6 +56,7 @@ install:
   - jsonapi_extras
   - consumers
   - inline_form_errors
+  - aggregator
   - simplesamlphp_auth
   - externalauth
   - config_update


### PR DESCRIPTION
This update installs and themes the Aggregator module and Aggregator feed block respectively. The block is available to be placed on a basic page via Layout Builder.

Sister PRs in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/202), [tiamat-project-template](https://github.com/CuBoulder/tiamat-project-template/pull/18)

CuBoulder/tiamat-theme#169