### PR TITLE
Adds "Advanced" appearance settings and custom site logos

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -190,6 +190,7 @@ permissions:
   - 'edit terms in newsletter'
   - 'edit terms in tags'
   - 'edit terms in ucb_person_job_type'
+  - 'edit ucb site advanced'
   - 'edit ucb site appearance'
   - 'edit ucb site contact info'
   - 'edit ucb site general'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -275,6 +275,7 @@ permissions:
   - 'edit terms in newsletter'
   - 'edit terms in tags'
   - 'edit terms in ucb_person_job_type'
+  - 'edit ucb site advanced'
   - 'edit ucb site appearance'
   - 'edit ucb site contact info'
   - 'edit ucb site general'


### PR DESCRIPTION
This update:
- Adds an _Advanced_ view at the bottom of the _Appearance_ settings, collapsed by default and visible only to those with the _Edit advanced site settings_ permission.
- Moves all theme settings previously restricted to Drupal's default theme settings into the _Advanced_ view.
- Adds site-specific custom logos (CuBoulder/tiamat-theme#264) and places the settings for custom logos into the _Advanced_ view:
  - Custom logo requires _white text on dark header_ and _dark text on white header_ variants.
  - An image can be uploaded or a path can be manually specified for each.
  - ~~A scale can be specified, which defaults to _2x_ (Retina) but also allows _1x_ (standard) or _3x_ (enhanced Retina)~~.
- Assigns the _Architect_ and _Developer_ user roles the _Edit advanced site settings_ permission.

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/19), [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/270)