### PR TITLE
Change: Adds Devel, Redirect, Migrate_plus required modules #26

### DIFF
--- a/boulderD9_profile.info.yml
+++ b/boulderD9_profile.info.yml
@@ -66,6 +66,10 @@ install:
   - pantheon_advanced_page_cache
   - simple_sitemap
   - antibot
+  - redirect
+  - migrate_plus
+  - devel
+  - devel_generate
   - cu_boulder_content_types
   - ucb_admin_menus
   - ucb_site_configuration

--- a/config/install/devel.settings.yml
+++ b/config/install/devel.settings.yml
@@ -1,0 +1,12 @@
+_core:
+  default_config_hash: Aqx6J0yYT6mVqT0fbjeP4JkoL-700nmudVF5d6Pq2Yo
+page_alter: false
+raw_names: false
+error_handlers:
+  1: 1
+rebuild_theme: false
+debug_mail_file_format: '%to-%subject-%datetime.mail.txt'
+debug_mail_directory: 'temporary://devel-mails'
+devel_dumper: var_dumper
+debug_logfile: 'temporary://drupal_debug.txt'
+debug_pre: true

--- a/config/install/devel.toolbar.settings.yml
+++ b/config/install/devel.toolbar.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: IQjf_ytthngZTAk_MU8-74VecArWD3G5g0oEH6PM6GA
+toolbar_items:
+  - devel.admin_settings_link
+  - devel.cache_clear
+  - devel.container_info.service
+  - devel.menu_rebuild
+  - devel.reinstall
+  - devel.route_info
+  - devel.run_cron

--- a/config/install/system.menu.devel.yml
+++ b/config/install/system.menu.devel.yml
@@ -1,0 +1,13 @@
+uuid: 4d15a5ea-11fb-43e5-ba85-b271e1667de6
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - devel
+_core:
+  default_config_hash: 3V-l1uuTcyirYOGLPZV5HWaDfr02uEbWZJIwc8Byz-c
+id: devel
+label: Development
+description: 'Links related to Devel module.'
+locked: true

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -1,3 +1,4 @@
+uuid: e9db6418-284f-4afd-a2f9-a6aba93bbcd9
 langcode: en
 status: true
 dependencies:
@@ -32,6 +33,8 @@ dependencies:
     - block
     - contact
     - contextual
+    - devel
+    - devel_generate
     - entity_reference_revisions
     - file
     - filter
@@ -48,6 +51,8 @@ dependencies:
     - ucb_site_configuration
     - ucb_user_invite
     - webform
+_core:
+  default_config_hash: pgmHZ6mQlyDIeRhmqLKaiUTOL5N-vOGYjL1cUjaHE5I
 id: architect
 label: Architect
 weight: 3
@@ -57,6 +62,7 @@ permissions:
   - 'access content'
   - 'access content overview'
   - 'access contextual links'
+  - 'access devel information'
   - 'access files overview'
   - 'access media overview'
   - 'access news feeds'
@@ -69,6 +75,7 @@ permissions:
   - 'access webform overview'
   - 'administer blocks'
   - 'administer contact forms'
+  - 'administer devel_generate'
   - 'administer menu'
   - 'administer news feeds'
   - 'administer search'
@@ -218,6 +225,7 @@ permissions:
   - 'revert ucb_person revisions'
   - 'search content'
   - 'switch shortcut sets'
+  - 'switch users'
   - 'update any media'
   - 'update media'
   - 'use advanced search'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -1,3 +1,4 @@
+uuid: 26b58cb8-b6cc-4ba6-9cf1-06d065db365f
 langcode: en
 status: true
 dependencies:
@@ -39,6 +40,8 @@ dependencies:
     - contact
     - contextual
     - crop
+    - devel
+    - devel_generate
     - embed
     - entity_reference_revisions
     - externalauth
@@ -63,6 +66,8 @@ dependencies:
     - ucb_user_invite
     - views_ui
     - webform
+_core:
+  default_config_hash: m1jzlHzzbhqBTVx0C84uTVMVORh5MsFUeUTFCl8VNMs
 id: developer
 label: Developer
 weight: 2
@@ -73,6 +78,7 @@ permissions:
   - 'access content'
   - 'access content overview'
   - 'access contextual links'
+  - 'access devel information'
   - 'access files overview'
   - 'access media overview'
   - 'access news feeds'
@@ -108,6 +114,7 @@ permissions:
   - 'administer content types'
   - 'administer crop'
   - 'administer crop types'
+  - 'administer devel_generate'
   - 'administer display modes'
   - 'administer embed buttons'
   - 'administer filters'
@@ -314,6 +321,7 @@ permissions:
   - 'revert ucb_person revisions'
   - 'search content'
   - 'switch shortcut sets'
+  - 'switch users'
   - 'synchronize configuration'
   - 'update any media'
   - 'update media'


### PR DESCRIPTION
Resolves #321 - Adds redirect, migrate_plus, devel and devel permissions to D9 and D10 project templates and profiles.

Includes:

- `tiamat-project-template`
- `tiamat10-project-template`
- `tiamat10-profile`
- `tiamat-profile`