### PR TITLE
Adds a global "Related articles" configuration form to CU Boulder Site Settings

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -77,7 +77,6 @@ permissions:
   - 'administer news feeds'
   - 'administer search'
   - 'administer ucb external services'
-  - 'administer ucb site'
   - 'administer user invite'
   - 'administer users'
   - 'administer webform element access'

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -1,4 +1,3 @@
-uuid: e9db6418-284f-4afd-a2f9-a6aba93bbcd9
 langcode: en
 status: true
 dependencies:
@@ -51,8 +50,6 @@ dependencies:
     - ucb_site_configuration
     - ucb_user_invite
     - webform
-_core:
-  default_config_hash: pgmHZ6mQlyDIeRhmqLKaiUTOL5N-vOGYjL1cUjaHE5I
 id: architect
 label: Architect
 weight: 3
@@ -87,6 +84,7 @@ permissions:
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'
+  - 'configure ucb related articles'
   - 'create and edit custom blocks'
   - 'create audio media'
   - 'create basic_page content'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -147,7 +147,6 @@ permissions:
   - 'administer taxonomy_term form display'
   - 'administer themes'
   - 'administer ucb external services'
-  - 'administer ucb site'
   - 'administer url aliases'
   - 'administer user display'
   - 'administer user fields'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -1,4 +1,3 @@
-uuid: 26b58cb8-b6cc-4ba6-9cf1-06d065db365f
 langcode: en
 status: true
 dependencies:
@@ -66,8 +65,6 @@ dependencies:
     - ucb_user_invite
     - views_ui
     - webform
-_core:
-  default_config_hash: m1jzlHzzbhqBTVx0C84uTVMVORh5MsFUeUTFCl8VNMs
 id: developer
 label: Developer
 weight: 2
@@ -165,6 +162,7 @@ permissions:
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'
+  - 'configure ucb related articles'
   - 'create and edit custom blocks'
   - 'create audio media'
   - 'create basic_page content'

--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -65,7 +65,6 @@ permissions:
   - 'administer contact forms'
   - 'administer menu'
   - 'administer ucb external services'
-  - 'administer ucb site'
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'

--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -69,6 +69,7 @@ permissions:
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'
+  - 'configure ucb related articles'
   - 'create and edit custom blocks'
   - 'create audio media'
   - 'create basic_page content'


### PR DESCRIPTION
This update adds a "Related articles" configuration form to CU Boulder Site Settings, accessible via the menu or `/admin/config/cu-boulder/related-articles`. Here users with permission can exclude articles with specific categories or tags from appearing in "related articles" sections. CuBoulder/ucb_site_configuration#22

This update also fixes a bug which caused warnings to appear when configuring a third-party service. CuBoulder/ucb_site_configuration#21

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/23), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/7)